### PR TITLE
Adding notional rates

### DIFF
--- a/assets/js/defi_rates.js
+++ b/assets/js/defi_rates.js
@@ -434,13 +434,13 @@ async function getNotionalApr() {
   }
 
   const aprToday = await fetch('https://api.thegraph.com/subgraphs/name/notional-finance/mainnet', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Accept': 'application/json',
-    },
-    body: JSON.stringify({
-      query: `query ($current_time: Int!) 
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      },
+      body: JSON.stringify({
+        query: `query ($current_time: Int!) 
         {
           cashMarkets(where:{ maturity_gt: $current_time }) {
             id
@@ -453,11 +453,11 @@ async function getNotionalApr() {
               maturityLength
             }
           }
-        }`
-    }),
-    variables: {
-      current_time: current_time
-    }
+        }`,
+      variables: {
+        current_time: current_time
+      }
+    })
   }).then(r => r.json());
 
   const daiRates = getRateArray(aprToday, "DAI")

--- a/assets/js/defi_rates.js
+++ b/assets/js/defi_rates.js
@@ -423,7 +423,7 @@ async function getAaveApr() {
 
 async function getNotionalApr() {
   const SECONDS_IN_YEAR = 31536000;
-  const current_time = (new Date()).getTime() / 1000
+  const current_time = Math.floor((new Date()).getTime() / 1000)
 
   const getRateArray = (results, currency) => {
     return results.data["cashMarkets"].filter((m) => {
@@ -456,7 +456,7 @@ async function getNotionalApr() {
         }`
     }),
     variables: {
-      current_time
+      current_time: current_time
     }
   }).then(r => r.json());
 

--- a/assets/js/defi_rates.js
+++ b/assets/js/defi_rates.js
@@ -421,19 +421,89 @@ async function getAaveApr() {
   }
 }
 
+async function getNotionalApr() {
+  const SECONDS_IN_YEAR = 31536000;
+  const current_time = (new Date()).getTime() / 1000
+
+  const getRateArray = (results, currency) => {
+    return results.data["cashMarkets"].filter((m) => {
+      return m.cashGroup.currency.symbol === currency
+    }).map((m) => {
+      return (m.lastImpliedRate * SECONDS_IN_YEAR / m.cashGroup.maturityLength) / 1e7
+    }).sort((a, b) => a - b)
+  }
+
+  const aprToday = await fetch('https://api.thegraph.com/subgraphs/name/notional-finance/mainnet', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+    },
+    body: JSON.stringify({
+      query: `query ($current_time: Int!) 
+        {
+          cashMarkets(where:{ maturity_gt: $current_time }) {
+            id
+            lastImpliedRate
+            maturity
+            cashGroup {
+              currency {
+                symbol
+              }
+              maturityLength
+            }
+          }
+        }`
+    }),
+    variables: {
+      current_time
+    }
+  }).then(r => r.json());
+
+  const daiRates = getRateArray(aprToday, "DAI")
+  const usdcRates = getRateArray(aprToday, "USDC")
+
+  return {
+    notional: {
+      supply: {
+        "dai": {
+          // Choose the highest rate between the different maturities available
+          "supply_rate": daiRates.length > 0 ? daiRates[daiRates.length - 1] : ''
+        },
+        "usdc": {
+          "supply_rate": usdcRates.length > 0 ? usdcRates[usdcRates.length - 1] : ''
+        }
+      },
+      borrow: {
+        "dai": {
+          // Choose the lowest rate between the different maturities available
+          "borrow_rate": daiRates.length > 0 ? daiRates[0] : ''
+        },
+        "usdc": {
+          "borrow_rate": usdcRates.length > 0 ? usdcRates[0] : ''
+        }
+      }
+    }
+  }
+}
+
+
 async function getAPRData() {
 
   const compoundData = await getCompoundApr();
   const dydxData = await getDydxApr();
   const aaveData = await getAaveApr();
   const fulcrumData = await getFulcrumApr();
+  const notionalData = await getNotionalApr();
+
   // const torqueData = await getTorqueApr();
   return {
     supply: {
       "compound_v2": compoundData.supply,
       "dydx": dydxData.supply,
       "aave": aaveData.aave.supply,
-      "fulcrum": fulcrumData.supply
+      "fulcrum": fulcrumData.supply,
+      "notional": notionalData.supply,
     },
     borrow: {
       "compound_v2": compoundData.borrow,
@@ -441,6 +511,7 @@ async function getAPRData() {
       "aave": aaveData.aave.borrow,
       "aave_fixed": aaveData.aave_fixed,
       "fulcrum": fulcrumData.borrow,
+      "notional": notionalData.borrow
       // "torque": torqueData
     }
   }

--- a/assets/js/defi_rates.js
+++ b/assets/js/defi_rates.js
@@ -464,24 +464,22 @@ async function getNotionalApr() {
   const usdcRates = getRateArray(aprToday, "USDC")
 
   return {
-    notional: {
-      supply: {
-        "dai": {
-          // Choose the highest rate between the different maturities available
-          "supply_rate": daiRates.length > 0 ? daiRates[daiRates.length - 1] : ''
-        },
-        "usdc": {
-          "supply_rate": usdcRates.length > 0 ? usdcRates[usdcRates.length - 1] : ''
-        }
+    supply: {
+      "dai": {
+        // Choose the highest rate between the different maturities available
+        "supply_rate": daiRates.length > 0 ? daiRates[daiRates.length - 1] : ''
       },
-      borrow: {
-        "dai": {
-          // Choose the lowest rate between the different maturities available
-          "borrow_rate": daiRates.length > 0 ? daiRates[0] : ''
-        },
-        "usdc": {
-          "borrow_rate": usdcRates.length > 0 ? usdcRates[0] : ''
-        }
+      "usdc": {
+        "supply_rate": usdcRates.length > 0 ? usdcRates[usdcRates.length - 1] : ''
+      }
+    },
+    borrow: {
+      "dai": {
+        // Choose the lowest rate between the different maturities available
+        "borrow_rate": daiRates.length > 0 ? daiRates[0] : ''
+      },
+      "usdc": {
+        "borrow_rate": usdcRates.length > 0 ? usdcRates[0] : ''
       }
     }
   }

--- a/defi_rates.md
+++ b/defi_rates.md
@@ -78,7 +78,7 @@ featured-image: /images/og-rates.png
                     </li>
                     <li class="item-crypto">
                         <a href="https://notional.finance/lend" class="inline-flex list-crypto-name list-liquidity-name">
-                            <span class="value" data-market="notional">Notional***</span>
+                            <span class="value" data-market="notional">Notional&#8224;</span>
                         </a>
                         <span class="list-crypto-today"></span>
                         <span class="list-crypto-month"></span>
@@ -129,7 +129,7 @@ featured-image: /images/og-rates.png
                     </li>
                     <li class="item-crypto">
                         <a href="https://notional.finance/lend" class="inline-flex list-crypto-name list-liquidity-name">
-                            <span class="value" data-market="notional">Notional***</span>
+                            <span class="value" data-market="notional">Notional&#8224;</span>
                         </a>
                         <span class="list-crypto-today"></span>
                         <span class="list-crypto-month"></span>
@@ -189,7 +189,7 @@ featured-image: /images/og-rates.png
                     </li>
                     <li class="item-crypto">
                         <a href="https://notional.finance/borrow" class="inline-flex list-crypto-name list-liquidity-name">
-                            <span class="value" data-market="notional">Notional***</span>
+                            <span class="value" data-market="notional">Notional&#8224;</span>
                         </a>
                         <span class="list-crypto-today"></span>
                         <span class="list-crypto-month"></span>
@@ -253,7 +253,7 @@ featured-image: /images/og-rates.png
                     </li>
                     <li class="item-crypto">
                         <a href="https://notional.finance/borrow" class="inline-flex list-crypto-name list-liquidity-name">
-                            <span class="value" data-market="notional">Notional***</span>
+                            <span class="value" data-market="notional">Notional&#8224;</span>
                         </a>
                         <span class="list-crypto-today"></span>
                         <span class="list-crypto-month"></span>
@@ -278,7 +278,7 @@ featured-image: /images/og-rates.png
     </div>
     <div class="description">*Loans with a fixed interest</div>
     <div class="description">**Loans as a part of margin trading platform</div>
-    <div class="description">*** Notional rates are fixed and available at various future maturities. Lowest borrow and highest lend rates are shown.</div>
+    <div class="description">&#8224; Notional rates are fixed and available at various future maturities. Lowest borrow and highest lend rates are shown.</div>
 
 </section>
 

--- a/defi_rates.md
+++ b/defi_rates.md
@@ -278,7 +278,7 @@ featured-image: /images/og-rates.png
     </div>
     <div class="description">*Loans with a fixed interest</div>
     <div class="description">**Loans as a part of margin trading platform</div>
-    <div class="description">* Notional rates are fixed and available at various future maturities. Lowest borrow and highest lend rates are shown.</div>
+    <div class="description">*** Notional rates are fixed and available at various future maturities. Lowest borrow and highest lend rates are shown.</div>
 
 </section>
 

--- a/defi_rates.md
+++ b/defi_rates.md
@@ -78,7 +78,7 @@ featured-image: /images/og-rates.png
                     </li>
                     <li class="item-crypto">
                         <a href="https://notional.finance/lend" class="inline-flex list-crypto-name list-liquidity-name">
-                            <span class="value" data-market="notional">Notional&#8224;</span>
+                            <span class="value" data-market="notional">Notional<sup>&#8224;</sup></span>
                         </a>
                         <span class="list-crypto-today"></span>
                         <span class="list-crypto-month"></span>
@@ -129,7 +129,7 @@ featured-image: /images/og-rates.png
                     </li>
                     <li class="item-crypto">
                         <a href="https://notional.finance/lend" class="inline-flex list-crypto-name list-liquidity-name">
-                            <span class="value" data-market="notional">Notional&#8224;</span>
+                            <span class="value" data-market="notional">Notional<sup>&#8224;</sup></span>
                         </a>
                         <span class="list-crypto-today"></span>
                         <span class="list-crypto-month"></span>
@@ -189,7 +189,7 @@ featured-image: /images/og-rates.png
                     </li>
                     <li class="item-crypto">
                         <a href="https://notional.finance/borrow" class="inline-flex list-crypto-name list-liquidity-name">
-                            <span class="value" data-market="notional">Notional&#8224;</span>
+                            <span class="value" data-market="notional">Notional<sup>&#8224;</sup></span>
                         </a>
                         <span class="list-crypto-today"></span>
                         <span class="list-crypto-month"></span>
@@ -253,7 +253,7 @@ featured-image: /images/og-rates.png
                     </li>
                     <li class="item-crypto">
                         <a href="https://notional.finance/borrow" class="inline-flex list-crypto-name list-liquidity-name">
-                            <span class="value" data-market="notional">Notional&#8224;</span>
+                            <span class="value" data-market="notional">Notional<sup>&#8224;</sup></span>
                         </a>
                         <span class="list-crypto-today"></span>
                         <span class="list-crypto-month"></span>
@@ -278,7 +278,7 @@ featured-image: /images/og-rates.png
     </div>
     <div class="description">*Loans with a fixed interest</div>
     <div class="description">**Loans as a part of margin trading platform</div>
-    <div class="description">&#8224; Notional rates are fixed and available at various future maturities. Lowest borrow and highest lend rates are shown.</div>
+    <div class="description"><sup>&#8224;</sup> Notional rates are fixed and available at various future maturities. Lowest borrow and highest lend rates are shown.</div>
 
 </section>
 

--- a/defi_rates.md
+++ b/defi_rates.md
@@ -76,6 +76,13 @@ featured-image: /images/og-rates.png
                         <span class="list-crypto-today"></span>
                         <span class="list-crypto-month"></span>
                     </li>
+                    <li class="item-crypto">
+                        <a href="https://notional.finance/lend" class="inline-flex list-crypto-name list-liquidity-name">
+                            <span class="value" data-market="notional">Notional***</span>
+                        </a>
+                        <span class="list-crypto-today"></span>
+                        <span class="list-crypto-month"></span>
+                    </li>
 
                     <!-- <li class="item-crypto">
                         <a href="https://oasis.app/save" class="inline-flex list-crypto-name list-liquidity-name">
@@ -116,6 +123,13 @@ featured-image: /images/og-rates.png
                     <li class="item-crypto">                        
                         <a href="https://trade.dydx.exchange/balances" class="inline-flex list-crypto-name list-liquidity-name">
                             <span class="value" data-market="dydx">dYdX</span>
+                        </a>
+                        <span class="list-crypto-today"></span>
+                        <span class="list-crypto-month"></span>
+                    </li>
+                    <li class="item-crypto">
+                        <a href="https://notional.finance/lend" class="inline-flex list-crypto-name list-liquidity-name">
+                            <span class="value" data-market="notional">Notional***</span>
                         </a>
                         <span class="list-crypto-today"></span>
                         <span class="list-crypto-month"></span>
@@ -169,6 +183,13 @@ featured-image: /images/og-rates.png
                     <li class="item-crypto">
                         <a href="https://trade.dydx.exchange/balances" class="inline-flex list-crypto-name list-liquidity-name">
                             <span class="value" data-market="dydx">dYdX</span>
+                        </a>
+                        <span class="list-crypto-today"></span>
+                        <span class="list-crypto-month"></span>
+                    </li>
+                    <li class="item-crypto">
+                        <a href="https://notional.finance/borrow" class="inline-flex list-crypto-name list-liquidity-name">
+                            <span class="value" data-market="notional">Notional***</span>
                         </a>
                         <span class="list-crypto-today"></span>
                         <span class="list-crypto-month"></span>
@@ -230,6 +251,13 @@ featured-image: /images/og-rates.png
                         <span class="list-crypto-today"></span>
                         <span class="list-crypto-month"></span>
                     </li>
+                    <li class="item-crypto">
+                        <a href="https://notional.finance/borrow" class="inline-flex list-crypto-name list-liquidity-name">
+                            <span class="value" data-market="notional">Notional***</span>
+                        </a>
+                        <span class="list-crypto-today"></span>
+                        <span class="list-crypto-month"></span>
+                    </li>
                     <!-- <li class="item-crypto">
                         <a href="https://fulcrum.trade/" class="inline-flex list-crypto-name list-liquidity-name">
                             <span class="value" data-market="fulcrum">Fulcrum**</span>
@@ -250,6 +278,7 @@ featured-image: /images/og-rates.png
     </div>
     <div class="description">*Loans with a fixed interest</div>
     <div class="description">**Loans as a part of margin trading platform</div>
+    <div class="description">* Notional rates are fixed and available at various future maturities. Lowest borrow and highest lend rates are shown.</div>
 
 </section>
 


### PR DESCRIPTION
Would it be possible to add this asterisk to our rates:

`* Notional rates are fixed and available at various future maturities. Lowest borrow and highest lend rates are shown.`

Also, it is possible (although highly unlikely) that we return nulls for the rates. I have it set to return an empty string '' in this case but lmk if I should do something different. I definitely don't want to break your site :)