### PR TITLE
Edit /_posts/2020-10-13-defi-taxes.md - Updated CoinLedger Urls

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -73,7 +73,7 @@ Klepatch:
 Kemmerer:
   name: David Kemmerer
   twitter: https://twitter.com/David_Kemmerer
-  bio: David Kemmerer is the CEO of <a href="http://cryptotrader.tax/">CryptoTrader.Tax</a>, a cryptocurrency tax reporting platform used by investors and traders all over the world.
+  bio: David Kemmerer is the CEO of <a href="https://coinledger.io">CoinLedger</a>, a cryptocurrency tax reporting platform used by investors and traders all over the world.
   image: /images/kemmerer.jpg
 Briggs:
   name: Aaron Briggs

--- a/collections/_posts/2020-10-13-defi-taxes.md
+++ b/collections/_posts/2020-10-13-defi-taxes.md
@@ -16,7 +16,7 @@ It’s no secret that DeFi has seen a massive influx of users in 2020. Individua
 
 In this guide, we’ll break down the tax implications of DeFi by looking at [existing cryptocurrency  tax guidance](https://www.irs.gov/businesses/small-businesses-self-employed/virtual-currencies) within the U.S.
 
-_This guide was created in-tandem with the tax professionals at [CryptoTrader.Tax](https://cryptotrader.tax/)._
+_This guide was created in-tandem with the tax professionals at [CoinLedger](https://coinledger.io)._
 
 
 ## The Basics of Cryptocurrency Taxes
@@ -92,7 +92,7 @@ For other DeFi platforms such as Aave, you earn interest directly to your wallet
 
 When looking at lending activities within DeFi, it’s important to assess how the interest is accruing. If it is being paid out directly to you, it is ordinary income. Contrary, if the interest rewards are accruing to the pool of which you have an LPT stake in, the income is treated as capital gains when you convert your LPT back to the underlying asset.
 
-For more information discussing the tax implications of specific DeFi protocols, refer to [this DeFi Tax Guide](https://cryptotrader.tax/blog/defi-crypto-tax-guide).
+For more information discussing the tax implications of specific DeFi protocols, refer to [this DeFi Tax Guide](https://coinledger.io/blog/defi-crypto-tax-guide).
 
 
 ## DeFi Token Swaps
@@ -154,7 +154,7 @@ Income earned from the interest on your cryptocurrency deposits/collateral shoul
 
 ## Cryptocurrency Tax Software
 
-Cryptocurrency tax software tools like [CryptoTrader.Tax](https://cryptotrader.tax/) can help automate your DeFi tax reporting. By integrating directly with platforms such as Uniswap, Compound, and others, you can use crypto tax software to import your transaction history and generate your capital gains and income tax reports with the click of a button.
+Cryptocurrency tax software tools like [CoinLedger](https://coinledger.io) can help automate your DeFi tax reporting. By integrating directly with platforms such as Uniswap, Compound, and others, you can use crypto tax software to import your transaction history and generate your capital gains and income tax reports with the click of a button.
 
 
 ## Conclusion


### PR DESCRIPTION
CryptoTrader.Tax rebranded to [CoinLedger](https://coinledger.io). Update here fixes the links and references inside the tax guide for clarify.