### PR TITLE
Add PM Wiki (prediction markets) and Perp Wiki (perps reference)

### DIFF
--- a/collections/_perps/Perp-Wiki.md
+++ b/collections/_perps/Perp-Wiki.md
@@ -1,0 +1,12 @@
+---
+git-date: 2026-03-10T00:00:00+00:00
+product-title: Perp Wiki
+product-url: https://perp.wiki/
+image: /images/output_md/perp.wiki.png
+ecosystem: ethereum, arbitrum, solana, base
+product-description: Perp Wiki is an open reference and analytics resource for perpetuals DEX traders. Compare protocols like dYdX, Hyperliquid, GMX and others — covering fees, funding rates, leverage limits, and available markets.
+coltitle: "Perps"
+colpermalink: perps
+twitter: https://twitter.com/perpwiki_
+alternative-to: dydx, hyperliquid
+---

--- a/collections/_prediction_markets/PM-Wiki.md
+++ b/collections/_prediction_markets/PM-Wiki.md
@@ -1,0 +1,12 @@
+---
+git-date: 2026-03-10T00:00:00+00:00
+product-title: PM Wiki
+product-url: https://pm.wiki/
+image: /images/output_md/pm.wiki.png
+ecosystem: ethereum, polygon, solana
+product-description: PM Wiki is an open reference and comparison tool for prediction markets. Browse and compare platforms like Polymarket, Kalshi, and Metaculus side by side — covering fees, markets, resolution rules, and liquidity.
+coltitle: "Prediction markets"
+colpermalink: prediction-markets
+twitter: https://twitter.com/pmwiki_
+alternative-to: polymarket, kalshi, metaculus
+---


### PR DESCRIPTION
## New project submissions

### PM Wiki — https://pm.wiki/
- **Category:** Prediction Markets
- **Description:** PM Wiki is an open reference and comparison tool for prediction markets. Browse and compare platforms like Polymarket, Kalshi, and Metaculus side by side — covering fees, markets, resolution rules, and liquidity.
- **Ecosystem:** Ethereum, Polygon, Solana
- **Live product** running and actively maintained

### Perp Wiki — https://perp.wiki/
- **Category:** Perps
- **Description:** Perp Wiki is an open reference and analytics resource for perpetuals DEX traders. Compare protocols like dYdX, Hyperliquid, GMX and others — covering fees, funding rates, leverage limits, and available markets.
- **Ecosystem:** Ethereum, Arbitrum, Solana, Base
- **Live product** running and actively maintained

Both sites are live, non-custodial reference tools with visible traction. No tokens sold.