### PR TITLE
Remove QuikNode from featured products

### DIFF
--- a/collections/_infrastructure/QuikNode.md
+++ b/collections/_infrastructure/QuikNode.md
@@ -4,7 +4,7 @@ product-title: QuikNode
 product-url: https://www.quicknode.com?tap_a=67226-09396e&tap_s=3231818-31f78f&utm_source=affiliate&utm_campaign=generic&utm_content=affiliate_landing_page&utm_medium=generic
 image: /images/output_md/www.quiknode.io.png
 ecosystem: ethereum, bitcoin, bsc, polygon
-featured: true
+featured: false
 product-description: QuikNode is a RPC node service provider with APIs & dedicated nodes available.
 coltitle: "Infrastructure"
 colpermalink: infrastructure


### PR DESCRIPTION
Set `featured: false` for QuikNode in the infrastructure category.