### PR TITLE
Add PredScope analytics platform

### DIFF
--- a/collections/_prediction_markets/PredScope.md
+++ b/collections/_prediction_markets/PredScope.md
@@ -1,0 +1,10 @@
+---
+git-date: 2026-03-31T12:00:00-07:00
+product-title: PredScope
+product-url: https://predscope.com/
+image: /images/output_md/predscope.png
+ecosystem: polygon
+product-description: PredScope is a prediction market analytics platform that tracks live odds, volumes, and price movements across platforms like Polymarket and Kalshi. Features include real-time market data for 500+ events, platform comparisons, trading guides, and a public API for developers.
+coltitle: "Prediction markets"
+colpermalink: prediction-markets
+---


### PR DESCRIPTION
PredScope (https://predscope.com/) is a prediction market analytics platform that provides:

- Live odds and price tracking for 500+ markets across Polymarket and Kalshi
- Real-time volume data, price movements, and market statistics  
- Platform reviews and comparison guides
- Public API at /api/markets.json for developers
- Trading guides and educational content

The platform tracks prediction markets on Polygon and provides free analytics to the community.