### PR TITLE
Add Sylision - P2P secondary marketplace for staked positions on Arbitrum

### DIFF
--- a/collections/_marketplaces/Sylision.md
+++ b/collections/_marketplaces/Sylision.md
@@ -1,0 +1,12 @@
+---
+git-date: 2026-05-15T00:00:00-03:00
+product-title: Sylision
+product-url: https://app.sylision.com
+image: /images/output_md/app.sylision.com.jpg
+ecosystem: arbitrum
+product-description: "Sylision is a P2P secondary marketplace where stakers sell locked positions early (at a 0-3% discount) and buyers earn staking yield plus an urgency bonus. Supports 30+ assets including ETH, DOT, ATOM, SOL, ADA, KSM and more."
+coltitle: "Marketplaces"
+filter: staking, DeFi, Arbitrum, marketplace, secondary market
+colpermalink: decentralized_marketplaces
+twitter: https://twitter.com/SylisionApp
+---


### PR DESCRIPTION
## Protocol
**Sylision** is a P2P marketplace where stakers sell locked positions at a discount and buyers earn staking yield + urgency bonus. First cross-chain secondary market for staked assets.

## Details
- **Website:** https://app.sylision.com
- **Twitter:** https://x.com/SylisionApp
- **Category:** Marketplace
- **Chain:** Arbitrum One

## TVL Methodology
Counts USDC and WETH held in the escrow contract representing staking positions listed for sale.

## Checklist
- [x] ecosystem: arbitrum set in frontmatter
- [x] coltitle and colpermalink match existing marketplaces format
- [x] product-description under 300 chars
- [x] Twitter handle included