### PR TITLE
feat: add WealthVille yield aggregator listing

### DIFF
--- a/collections/_yield-aggregators/WealthVille.md
+++ b/collections/_yield-aggregators/WealthVille.md
@@ -1,0 +1,12 @@
+---
+git-date: 2026-05-29T12:00:00+05:30
+product-title: WealthVille
+product-url: https://wealthville.net/
+image: /images/output_md/wealthville.jpg
+ecosystem: solana
+product-description: WealthVille is a non-custodial automated yield optimizer on Solana. Keeper bots auto-compound LP rewards across Orca Whirlpools, Raydium AMM, CLMM, and CPMM — users deposit once and earn optimized yield without manual harvesting. ~$14.2M TVL, 24 active vaults, AI-powered pool discovery and Telegram signals.
+coltitle: "Yield Aggregators"
+colpermalink: yield-aggregators
+twitter: https://twitter.com/wealthville_net
+telegram: https://t.me/wealthville_signals
+---


### PR DESCRIPTION
Adds WealthVille to the Yield Aggregators section. WealthVille is a non-custodial automated yield optimizer built natively on Solana. Keeper bots auto-compound LP rewards across Orca Whirlpools, Raydium AMM, CLMM, and CPMM. ~$14.2M TVL, 24 active vaults. Website: https://wealthville.net | Twitter: https://twitter.com/wealthville_net